### PR TITLE
CI: skip heavy artifacts in UI self-test

### DIFF
--- a/.github/workflows/ui-selftest.yml
+++ b/.github/workflows/ui-selftest.yml
@@ -7,6 +7,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with: { python-version: "3.11" }
+      - name: Set skip flags (no heavy native deps)
+        run: |
+          echo "SELFTEST_SKIP_ARTIFACTS=1" >> $GITHUB_ENV
+          echo "CI=true" >> $GITHUB_ENV
       - name: Install minimal deps
         run: |
           python -m pip install -U pip requests

--- a/solhunter_zero/_preflight.py
+++ b/solhunter_zero/_preflight.py
@@ -51,6 +51,9 @@ def rpc_blockhash(url: str, timeout=8):
 
 
 def check_artifacts():
+    """Verify compiled artifacts exist (skipped in CI for speed)."""
+    if os.getenv("SELFTEST_SKIP_ARTIFACTS") == "1" or os.getenv("CI") == "true":
+        return
     # Package-relative FFI
     if not any(PKG_ROOT.glob("libroute_ffi.*")):
         raise RuntimeError(f"Missing FFI library at {PKG_ROOT}/libroute_ffi.*")

--- a/solhunter_zero/agent_manager.py
+++ b/solhunter_zero/agent_manager.py
@@ -39,7 +39,12 @@ from .agents.memory import MemoryAgent
 from .agents.emotion_agent import EmotionAgent
 from .agents.discovery import DiscoveryAgent
 from .swarm_coordinator import SwarmCoordinator
-from .agents.attention_swarm import AttentionSwarm, load_model
+try:  # optional torch-based swarm
+    from .agents.attention_swarm import AttentionSwarm, load_model
+except Exception:  # pragma: no cover - torch not available
+    AttentionSwarm = None  # type: ignore
+    def load_model(*args, **kwargs):  # type: ignore
+        raise ImportError("AttentionSwarm requires torch")
 from .agents.rl_weight_agent import RLWeightAgent
 from .agents.hierarchical_rl_agent import HierarchicalRLAgent
 from .device import get_default_device


### PR DESCRIPTION
## Summary
- skip native artifact checks in CI preflight
- mark AttentionSwarm optional to avoid torch requirement
- export skip flags in ui-selftest workflow

## Testing
- `python -m compileall solhunter_zero/agent_manager.py`
- `flake8 solhunter_zero/agent_manager.py` *(fails: F841, E301, E501, W293, etc.)*
- `SELFTEST_SKIP_ARTIFACTS=1 CI=true SOLHUNTER_PATCH_INVESTOR_DEMO=1 pytest tests/test_ui.py -q` *(fails: RuntimeError: Working outside of request context)*
- `SOLHUNTER_CONFIG=config_selftest.toml SELFTEST_SKIP_ARTIFACTS=1 CI=true SOLHUNTER_PATCH_INVESTOR_DEMO=1 python -m solhunter_zero.ui --selftest`

------
https://chatgpt.com/codex/tasks/task_e_68ae801b45108331b3baad54fc267425