### PR TITLE
Enforce mandatory RL daemon health checks

### DIFF
--- a/.github/workflows/fullstack-smoke.yml
+++ b/.github/workflows/fullstack-smoke.yml
@@ -1,0 +1,36 @@
+name: fullstack-smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      use_redis:
+        description: "Require Redis gate (1/0)"
+        default: "0"
+      check_ui:
+        description: "Poll UI /healthz (1/0)"
+        default: "0"
+      rl_health_url:
+        description: "RL daemon health URL (required)"
+        default: "http://127.0.0.1:7070/health"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Paper-safe env
+        run: |
+          [ -f .env.example ] && cp .env.example .env || true
+          echo "ENV=dev" >> .env
+          echo "RISK_MODE=paper" >> .env
+          echo "USE_REDIS=${{ github.event.inputs.use_redis }}" >> $GITHUB_ENV
+          echo "CHECK_UI_HEALTH=${{ github.event.inputs.check_ui }}" >> $GITHUB_ENV
+          echo "RL_HEALTH_URL=${{ github.event.inputs.rl_health_url }}" >> $GITHUB_ENV
+      - name: Install package
+        run: python -m pip install -e .
+      - name: Run smoke
+        run: python scripts/smoke_fullstack.py
+

--- a/.github/workflows/ui-selftest.yml
+++ b/.github/workflows/ui-selftest.yml
@@ -35,4 +35,4 @@ PY
         run: |
           python -m pip install -U pytest
           # targeted, fast unit tests
-          pytest -q tests/test_selftest.py
+          pytest -q tests/test_selftest.py tests/test_startup_integration.py

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ python -m solhunter_zero.ui --selftest
 ```
 This runs the same checks the full orchestrator will rely on, but isolated—so failures are clean and actionable.
 
+### Full-stack smoke (paper-safe)
+Run the on-demand smoke locally:
+```bash
+USE_REDIS=1 CHECK_UI_HEALTH=1 RL_HEALTH_URL=http://127.0.0.1:7070/health \
+SELFTEST_SKIP_ARTIFACTS=1 CI=true \
+python scripts/smoke_fullstack.py
+```
+
 Use `--min-delay` or `--max-delay` from the CLI to bound the delay between trade iterations during manual runs.
 
 The mandatory Rust `depth_service` is already enabled and starts automatically, so no extra step is required. All optional agents are enabled by default and wallet selection is always manual. Offline data (around two to three days of history, capped at 50 GB by default) downloads automatically. Set `OFFLINE_DATA_LIMIT_GB` to adjust the size limit. The bot begins with an initial $20 balance linked to [`min_portfolio_value`](#minimum-portfolio-value).

--- a/scripts/smoke_fullstack.py
+++ b/scripts/smoke_fullstack.py
@@ -1,0 +1,47 @@
+"""Full-stack smoke test for SolHunter Zero.
+
+This script performs lightweight health checks to verify that core services
+are reachable.  It is intended for CI and local paper trading environments and
+therefore keeps dependencies to a minimum.
+
+The RL daemon is now mandatory; the script fails fast when the service is not
+healthy.
+"""
+
+from __future__ import annotations
+
+import os
+from solhunter_zero.health_runtime import check_redis, http_ok, wait_for
+
+
+def fail(msg: str) -> int:
+    print(msg)
+    return 1
+
+
+def main() -> int:
+    EVENT_BUS_URL = os.getenv("EVENT_BUS_URL", "redis://127.0.0.1:6379/0")
+    RL_HEALTH_URL = os.getenv("RL_HEALTH_URL", "http://127.0.0.1:7070/health")
+    UI_HEALTH_URL = os.getenv("UI_HEALTH_URL")
+
+    if os.getenv("USE_REDIS", "0") == "1":
+        ok, msg = wait_for(lambda: check_redis(EVENT_BUS_URL))
+        if not ok:
+            return fail(f"Redis: {msg}")
+
+    # RL daemon is mandatory in smoke as well
+    ok, msg = wait_for(lambda: http_ok(RL_HEALTH_URL))
+    if not ok:
+        return fail(f"RL daemon: {msg}")
+
+    if os.getenv("CHECK_UI_HEALTH", "0") == "1" and UI_HEALTH_URL:
+        ok, msg = wait_for(lambda: http_ok(UI_HEALTH_URL))
+        if not ok:
+            return fail(f"UI: {msg}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    raise SystemExit(main())
+

--- a/solhunter_zero/health_runtime.py
+++ b/solhunter_zero/health_runtime.py
@@ -1,0 +1,96 @@
+"""Runtime health check utilities.
+
+This module provides lightweight, dependency-free helpers used by runtime
+startup scripts to verify that required services are available.  The checks are
+designed to be simple and fast so they can execute in constrained CI
+environments without external services.
+"""
+
+from __future__ import annotations
+
+import socket
+import time
+import urllib.parse
+import urllib.request
+from typing import Callable, Tuple
+
+CheckResult = Tuple[bool, str]
+
+
+def check_redis(url: str) -> CheckResult:
+    """Verify that a Redis server is reachable at ``url``.
+
+    The function performs a plain TCP connection check so it does not require
+    the ``redis`` package to be installed.
+    """
+
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 6379
+    try:
+        with socket.create_connection((host, port), timeout=1.0):
+            return True, "ok"
+    except OSError as exc:  # pragma: no cover - network failure paths
+        return False, str(exc)
+
+
+def check_depth_service() -> CheckResult:
+    """Placeholder depth service check.
+
+    In a production environment this would verify the presence and health of
+    the Rust ``depth_service`` binary.  For tests we simply report success.
+    """
+
+    return True, "ok"
+
+
+def check_ffi() -> CheckResult:
+    """Placeholder FFI library check.
+
+    The actual project performs a more elaborate verification of the compiled
+    FFI bindings.  Here we merely signal success to keep the check lightweight.
+    """
+
+    return True, "ok"
+
+
+def http_ok(url: str) -> CheckResult:
+    """Return ``(True, msg)`` if an HTTP GET request succeeds.
+
+    The ``msg`` contains the HTTP status code on success or the exception text
+    on failure.
+    """
+
+    try:
+        with urllib.request.urlopen(url, timeout=1.0) as resp:  # noqa: S310
+            return 200 <= resp.status < 400, f"http {resp.status}"
+    except Exception as exc:  # pragma: no cover - network failure paths
+        return False, str(exc)
+
+
+def wait_for(
+    func: Callable[[], CheckResult],
+    *,
+    retries: int = 30,
+    sleep: float = 0.5,
+) -> CheckResult:
+    """Poll ``func`` until it reports success or ``retries`` is exhausted."""
+
+    last: CheckResult = (False, "no result")
+    for _ in range(retries):
+        ok, msg = func()
+        last = (ok, msg)
+        if ok:
+            return last
+        time.sleep(sleep)
+    return last
+
+
+__all__ = [
+    "check_redis",
+    "check_depth_service",
+    "check_ffi",
+    "http_ok",
+    "wait_for",
+]
+

--- a/start_all.py
+++ b/start_all.py
@@ -1,0 +1,82 @@
+"""Runtime startup health gates for SolHunter Zero.
+
+This lightweight entrypoint performs a series of health checks before the
+full application is allowed to start.  The UI self-test is executed first and
+any non-zero exit code aborts immediately.  A healthy RL daemon is now a
+*mandatory* requirement – startup will fail fast if the RL service cannot be
+reached.
+
+The individual checks can be relaxed via environment variables which default
+to paper-safe values so that tests can run without heavy services.
+"""
+
+from __future__ import annotations
+
+from solhunter_zero.ui import ui_selftest
+from solhunter_zero.health_runtime import (
+    check_redis,
+    check_depth_service,
+    check_ffi,
+    wait_for,
+    http_ok,
+)
+import os
+import logging
+
+
+log = logging.getLogger("start_all")
+
+
+def main() -> int:
+    """Execute startup health gates.
+
+    Returns ``0`` when all required checks pass.  ``SystemExit`` is raised with
+    a descriptive message when any gate fails.
+    """
+
+    rc = ui_selftest()
+    if rc != 0:
+        raise SystemExit(rc)
+
+    # Runtime health gates (paper-safe by default; can be relaxed via env)
+    EVENT_BUS_URL = os.getenv("EVENT_BUS_URL", "redis://127.0.0.1:6379/0")
+    # RL daemon is MANDATORY
+    RL_HEALTH_URL = os.getenv("RL_HEALTH_URL", "http://127.0.0.1:7070/health")
+    UI_HEALTH_URL = os.getenv("UI_HEALTH_URL", "http://127.0.0.1:3000/healthz")
+
+    if os.getenv("USE_REDIS", "1") == "1":
+        ok, msg = wait_for(lambda: check_redis(EVENT_BUS_URL))
+        if not ok:
+            raise SystemExit(f"Redis gate failed: {msg}")
+        log.info("Redis reachable: %s", EVENT_BUS_URL)
+
+    # RL daemon is required — do not proceed without a healthy RL service
+    ok, msg = wait_for(lambda: http_ok(RL_HEALTH_URL), retries=60, sleep=1.0)
+    if not ok:
+        raise SystemExit(f"RL daemon gate failed: {msg}")
+    log.info("RL daemon healthy: %s", RL_HEALTH_URL)
+
+    if os.getenv("CHECK_UI_HEALTH", "1") == "1":
+        ok, msg = wait_for(lambda: http_ok(UI_HEALTH_URL))
+        if not ok:
+            raise SystemExit(f"UI gate failed: {msg}")
+        log.info("UI healthy: %s", UI_HEALTH_URL)
+
+    if os.getenv("CHECK_DEPTH_SERVICE", "0") == "1":
+        ok, msg = wait_for(check_depth_service)
+        if not ok:
+            raise SystemExit(f"Depth service gate failed: {msg}")
+        log.info("Depth service ready")
+
+    if os.getenv("CHECK_FFI", "0") == "1":
+        ok, msg = wait_for(check_ffi)
+        if not ok:
+            raise SystemExit(f"FFI gate failed: {msg}")
+        log.info("FFI ready")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    raise SystemExit(main())
+

--- a/tests/test_startup_integration.py
+++ b/tests/test_startup_integration.py
@@ -1,0 +1,66 @@
+"""Integration tests for the lightweight startup gates."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+def test_start_all_respects_ui_selftest_exit_code(monkeypatch):
+    import start_all
+
+    monkeypatch.setenv("SELFTEST_SKIP_ARTIFACTS", "1")
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("USE_REDIS", "0")
+    monkeypatch.setenv("CHECK_UI_HEALTH", "0")
+    monkeypatch.setenv("RL_HEALTH_URL", "http://rl:7070/health")
+
+    with patch("start_all.ui_selftest", return_value=2):
+        with pytest.raises(SystemExit) as exc:
+            start_all.main()
+        assert exc.value.code == 2
+
+
+def test_start_all_blocks_when_rl_unhealthy(monkeypatch):
+    """RL daemon is mandatory: unhealthy RL must block startup."""
+
+    import start_all
+
+    # Bypass preflight success
+    monkeypatch.setenv("SELFTEST_SKIP_ARTIFACTS", "1")
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("USE_REDIS", "0")  # don't require Redis in this unit test
+    monkeypatch.setenv("CHECK_UI_HEALTH", "0")  # don't poll UI in this unit test
+    monkeypatch.setenv("RL_HEALTH_URL", "http://rl:7070/health")
+
+    with patch("start_all.ui_selftest", return_value=0):
+        # Prevent long waits: force wait_for to return unhealthy quickly
+        with patch("start_all.wait_for", return_value=(False, "down")):
+            with pytest.raises(SystemExit) as exc:
+                start_all.main()
+            # Any non-zero code is fine; message should mention RL gate
+            assert "RL daemon gate failed" in str(exc.value)
+
+
+def test_start_all_allows_when_rl_healthy(monkeypatch):
+    """Healthy RL gate must pass."""
+
+    import start_all
+
+    # Bypass preflight success
+    monkeypatch.setenv("SELFTEST_SKIP_ARTIFACTS", "1")
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("USE_REDIS", "0")
+    monkeypatch.setenv("CHECK_UI_HEALTH", "0")
+    monkeypatch.setenv("RL_HEALTH_URL", "http://rl:7070/health")
+
+    with patch("start_all.ui_selftest", return_value=0):
+        # Make RL gate healthy; also don't block on other waits
+        with patch("start_all.wait_for", return_value=(True, "ok")):
+            try:
+                start_all.main()
+            except SystemExit as e:
+                # If later gates exit, ensure it's NOT the RL gate
+                assert "RL daemon gate failed" not in str(e)
+


### PR DESCRIPTION
## Summary
- add lightweight `start_all` runtime gate requiring a healthy RL daemon
- make `smoke_fullstack.py` and on-demand workflow fail fast when RL service is absent
- add integration tests and CI wiring for RL gate

## Testing
- `pytest -q tests/test_selftest.py tests/test_startup_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68aea97400f08331b8bf205e126bb1a0