### PR TITLE
Runtime soak script and workflow

### DIFF
--- a/.github/workflows/runtime-soak.yml
+++ b/.github/workflows/runtime-soak.yml
@@ -1,0 +1,45 @@
+name: Runtime Soak (on-demand)
+on:
+  workflow_dispatch:
+    inputs:
+      duration_sec:
+        description: "Soak duration (seconds)"
+        default: "180"
+      use_redis:
+        description: "Require Redis gate (1/0)"
+        default: "0"
+      check_ui:
+        description: "Poll UI /healthz (1/0)"
+        default: "0"
+      rl_health_url:
+        description: "RL daemon health URL (required)"
+        default: "http://127.0.0.1:7070/health"
+      ui_health_url:
+        description: "UI health URL"
+        default: "http://127.0.0.1:3000/healthz"
+jobs:
+  soak:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: python -m pip install -U pip requests
+      - name: Paper-safe env
+        run: |
+          echo "ENV=dev" >> $GITHUB_ENV
+          echo "RISK_MODE=paper" >> $GITHUB_ENV
+          echo "SELFTEST_SKIP_ARTIFACTS=1" >> $GITHUB_ENV
+          echo "CI=true" >> $GITHUB_ENV
+          echo "DURATION_SEC=${{ github.event.inputs.duration_sec }}" >> $GITHUB_ENV
+          echo "USE_REDIS=${{ github.event.inputs.use_redis }}" >> $GITHUB_ENV
+          echo "CHECK_UI_HEALTH=${{ github.event.inputs.check_ui }}" >> $GITHUB_ENV
+          echo "RL_HEALTH_URL=${{ github.event.inputs.rl_health_url }}" >> $GITHUB_ENV
+          echo "UI_HEALTH_URL=${{ github.event.inputs.ui_health_url }}" >> $GITHUB_ENV
+          echo "SOLANA_RPC_URL=https://api.mainnet-beta.solana.com" >> $GITHUB_ENV
+          mkdir -p keypairs && echo "[1,2,3,4]" > keypairs/bot.json
+          echo "KEYPAIR_PATH=./keypairs/bot.json" >> $GITHUB_ENV
+      - name: Run soak
+        run: python scripts/soak_runtime.py

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ SELFTEST_SKIP_ARTIFACTS=1 CI=true \
 python scripts/smoke_fullstack.py
 ```
 
+### Runtime Soak (on-demand)
+Prove the whole system keeps rolling in paper mode:
+```bash
+RL_HEALTH_URL=http://127.0.0.1:7070/health \
+CHECK_UI_HEALTH=1 UI_HEALTH_URL=http://127.0.0.1:3000/healthz \
+USE_REDIS=1 EVENT_BUS_URL=redis://127.0.0.1:6379/0 \
+SELFTEST_SKIP_ARTIFACTS=1 CI=true DURATION_SEC=180 \
+python scripts/soak_runtime.py
+```
+Or trigger **Runtime Soak (on-demand)** in GitHub Actions and set inputs.
+
 Use `--min-delay` or `--max-delay` from the CLI to bound the delay between trade iterations during manual runs.
 
 The mandatory Rust `depth_service` is already enabled and starts automatically, so no extra step is required. All optional agents are enabled by default and wallet selection is always manual. Offline data (around two to three days of history, capped at 50 GB by default) downloads automatically. Set `OFFLINE_DATA_LIMIT_GB` to adjust the size limit. The bot begins with an initial $20 balance linked to [`min_portfolio_value`](#minimum-portfolio-value).

--- a/scripts/soak_runtime.py
+++ b/scripts/soak_runtime.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Paper-safe runtime soak:
+- For DURATION seconds, repeatedly:
+    * Check RL daemon health (mandatory)
+    * Optionally check UI /healthz (CHECK_UI_HEALTH=1)
+    * Optionally check Redis TCP reachability (USE_REDIS=1)
+    * Periodically hit Solana RPC getLatestBlockhash (if SOLANA_RPC_URL set)
+- At end, compute success ratios and fail if below thresholds.
+
+Env (with sensible defaults):
+  DURATION_SEC=180
+  RL_HEALTH_URL=http://127.0.0.1:7070/health      (mandatory)
+  UI_HEALTH_URL=http://127.0.0.1:3000/healthz
+  CHECK_UI_HEALTH=1
+  USE_REDIS=1
+  EVENT_BUS_URL=redis://127.0.0.1:6379/0
+  SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+  # thresholds (fraction 0..1):
+  MIN_OK_RL=0.98
+  MIN_OK_UI=0.95
+  MIN_OK_REDIS=0.95
+  MIN_OK_RPC=0.90
+"""
+from __future__ import annotations
+import os, time, json, socket, contextlib, urllib.request
+from typing import Tuple
+
+def envf(name, default):
+    try:
+        return float(os.getenv(name, default))
+    except Exception:
+        return float(default)
+
+def http_ok(url: str, timeout: float = 2.0) -> Tuple[bool, str]:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return (200 <= r.status < 500), f"status={r.status}"
+    except Exception as e:
+        return False, f"error:{e}"
+
+def redis_ok(url: str, timeout: float = 1.5) -> Tuple[bool, str]:
+    if not url.startswith("redis://"):
+        return False, f"bad_scheme:{url}"
+    hostport = url.split("redis://", 1)[1].split("/", 1)[0]
+    host, port = (hostport.split(":")[0], int(hostport.split(":")[1])) if ":" in hostport else (hostport, 6379)
+    try:
+        with contextlib.closing(socket.create_connection((host, port), timeout=timeout)):
+            return True, "ok"
+    except Exception as e:
+        return False, f"error:{e}"
+
+def rpc_blockhash(url: str, timeout: float = 3.0) -> Tuple[bool, str]:
+    import urllib.request, json as _json
+    req = urllib.request.Request(
+        url,
+        data=_json.dumps({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "getLatestBlockhash",
+            "params": [{"commitment": "processed"}],
+        }).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            if r.status >= 400:
+                return False, f"status={r.status}"
+            j = _json.loads(r.read().decode("utf-8"))
+            ok = "result" in j
+            return ok, "ok" if ok else "no_result"
+    except Exception as e:
+        return False, f"error:{e}"
+
+def main():
+    duration = int(os.getenv("DURATION_SEC", "180"))
+    rl_url = os.getenv("RL_HEALTH_URL", "http://127.0.0.1:7070/health")
+    ui_url = os.getenv("UI_HEALTH_URL", "http://127.0.0.1:3000/healthz")
+    check_ui = os.getenv("CHECK_UI_HEALTH", "1") == "1"
+    use_redis = os.getenv("USE_REDIS", "1") == "1"
+    redis_url = os.getenv("EVENT_BUS_URL", "redis://127.0.0.1:6379/0")
+    rpc_url = os.getenv("SOLANA_RPC_URL", "https://api.mainnet-beta.solana.com")
+
+    min_ok_rl = envf("MIN_OK_RL", 0.98)
+    min_ok_ui = envf("MIN_OK_UI", 0.95)
+    min_ok_redis = envf("MIN_OK_REDIS", 0.95)
+    min_ok_rpc = envf("MIN_OK_RPC", 0.90)
+
+    # counters
+    total = 0
+    rl_ok = ui_ok = red_ok = rpc_okc = 0
+
+    t0 = time.time()
+    last_rpc = 0.0
+    last_red = 0.0
+    while time.time() - t0 < duration:
+        total += 1
+        ok, _ = http_ok(rl_url)
+        rl_ok += 1 if ok else 0
+
+        if check_ui:
+            ok, _ = http_ok(ui_url)
+            ui_ok += 1 if ok else 0
+
+        now = time.time()
+        if use_redis and now - last_red >= 5.0:
+            ok, _ = redis_ok(redis_url)
+            red_ok += 1 if ok else 0
+            last_red = now
+
+        if rpc_url and now - last_rpc >= 10.0:
+            ok, _ = rpc_blockhash(rpc_url)
+            rpc_okc += 1 if ok else 0
+            last_rpc = now
+
+        time.sleep(1.0)
+
+    # compute denominators
+    ui_den = total if check_ui else 1
+    red_den = max(1, int((time.time() - t0) // 5))
+    rpc_den = max(1, int((time.time() - t0) // 10))
+
+    metrics = {
+        "duration_sec": duration,
+        "rl_ok_ratio": (rl_ok / total) if total else 0.0,
+        "ui_ok_ratio": (ui_ok / ui_den) if ui_den else 1.0,
+        "redis_ok_ratio": (red_ok / red_den) if use_redis else 1.0,
+        "rpc_ok_ratio": (rpc_okc / rpc_den),
+        "thresholds": {
+            "rl": min_ok_rl,
+            "ui": min_ok_ui,
+            "redis": min_ok_redis,
+            "rpc": min_ok_rpc,
+        },
+    }
+    print(json.dumps({"ok": True, "metrics": metrics}, indent=2))
+
+    failures = []
+    if metrics["rl_ok_ratio"] < min_ok_rl:
+        failures.append(f"RL {metrics['rl_ok_ratio']:.2%} < {min_ok_rl:.0%}")
+    if check_ui and metrics["ui_ok_ratio"] < min_ok_ui:
+        failures.append(f"UI {metrics['ui_ok_ratio']:.2%} < {min_ok_ui:.0%}")
+    if use_redis and metrics["redis_ok_ratio"] < min_ok_redis:
+        failures.append(f"Redis {metrics['redis_ok_ratio']:.2%} < {min_ok_redis:.0%}")
+    if metrics["rpc_ok_ratio"] < min_ok_rpc:
+        failures.append(f"RPC {metrics['rpc_ok_ratio']:.2%} < {min_ok_rpc:.0%}")
+
+    if failures:
+        print(json.dumps({"ok": False, "failures": failures}, indent=2))
+        return 2
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add paper-safe runtime soak script that checks RL daemon, UI health, Redis and Solana RPC
- provide on-demand GitHub Action to run the runtime soak
- document runtime soak usage in README

## Testing
- `python -m compileall .`
- `flake8` *(fails: E402 module level import not at top of file, E501 line too long, etc.)*
- `pytest` *(fails: ImportError: cannot import name 'ENV_VARS', TypeError: function() argument 'code' must be code, not str)*

------
https://chatgpt.com/codex/tasks/task_e_68aeadcae2e88331ac6fcb1851248665