### PR TITLE
CI: E2E Actions run — Redis + Mock RL/UI + selftest + smoke + start_all gates

### DIFF
--- a/.github/workflows/e2e-all-systems-go.yml
+++ b/.github/workflows/e2e-all-systems-go.yml
@@ -1,0 +1,53 @@
+name: E2E — All Systems Go (paper-safe)
+on:
+  push:
+  workflow_dispatch:
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping || exit 1"
+          --health-interval 2s
+          --health-timeout 1s
+          --health-retries 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Install deps
+        run: |
+          python -m pip install -U pip requests fastapi uvicorn pytest
+      - name: Start Mock RL (port 7070)
+        run: |
+          nohup python -m uvicorn scripts.mock_rl:app --host 0.0.0.0 --port 7070 >/tmp/mock_rl.log 2>&1 &
+          sleep 1
+      - name: Start Mock UI (port 8002)
+        run: |
+          nohup python scripts/mock_ui.py >/tmp/mock_ui.log 2>&1 &
+          sleep 1
+      - name: Paper-safe env (+ gates)
+        run: |
+          echo "ENV=dev" >> $GITHUB_ENV
+          echo "RISK_MODE=paper" >> $GITHUB_ENV
+          echo "CI=true" >> $GITHUB_ENV
+          echo "SELFTEST_SKIP_ARTIFACTS=1" >> $GITHUB_ENV
+          echo "USE_REDIS=1" >> $GITHUB_ENV
+          echo "EVENT_BUS_URL=redis://127.0.0.1:6379/0" >> $GITHUB_ENV
+          echo "RL_HEALTH_URL=http://127.0.0.1:7070/health" >> $GITHUB_ENV
+          echo "CHECK_UI_HEALTH=1" >> $GITHUB_ENV
+          echo "UI_HEALTH_URL=http://127.0.0.1:8002/healthz" >> $GITHUB_ENV
+          echo "SOLANA_RPC_URL=https://api.mainnet-beta.solana.com" >> $GITHUB_ENV
+          echo "START_ALL_EXIT_AFTER_GATES=1" >> $GITHUB_ENV
+          mkdir -p keypairs && echo "[1,2,3,4]" > keypairs/bot.json
+          echo "KEYPAIR_PATH=$(pwd)/keypairs/bot.json" >> $GITHUB_ENV
+      - name: UI Self-test
+        run: python -m solhunter_zero.ui --selftest
+      - name: Full-stack Smoke
+        run: python scripts/smoke_fullstack.py
+      - name: Start-all (exit after gates)
+        run: python start_all.py

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ python scripts/soak_runtime.py
 ```
 Or trigger **Runtime Soak (on-demand)** in GitHub Actions and set inputs.
 
+### E2E in GitHub Actions (paper-safe)
+An on-demand workflow **E2E — All Systems Go** spins up Redis + mock RL + mock UI, runs the UI self-test, the full-stack smoke, and `start_all.py` (exits after gates). Trigger it from the Actions tab or push to any branch.
+
 Use `--min-delay` or `--max-delay` from the CLI to bound the delay between trade iterations during manual runs.
 
 The mandatory Rust `depth_service` is already enabled and starts automatically, so no extra step is required. All optional agents are enabled by default and wallet selection is always manual. Offline data (around two to three days of history, capped at 50 GB by default) downloads automatically. Set `OFFLINE_DATA_LIMIT_GB` to adjust the size limit. The bot begins with an initial $20 balance linked to [`min_portfolio_value`](#minimum-portfolio-value).

--- a/scripts/mock_rl.py
+++ b/scripts/mock_rl.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+@app.get("/health")
+def health():
+    return {"ok": True, "component": "mock_rl"}
+
+
+class Obs(BaseModel):
+    state: dict | None = None
+
+
+@app.post("/decide")
+def decide(obs: Obs):
+    # Always return a benign "hold" decision in paper mode
+    return {"action": "hold", "confidence": 0.5}

--- a/scripts/mock_ui.py
+++ b/scripts/mock_ui.py
@@ -1,0 +1,26 @@
+import http.server
+import socketserver
+import json
+import os
+
+PORT = int(os.getenv("MOCK_UI_PORT", "8002"))
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if self.path.startswith("/healthz"):
+            payload = json.dumps({"ok": True, "component": "mock_ui"}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        else:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"mock ui")
+
+
+if __name__ == "__main__":
+    with socketserver.TCPServer(("0.0.0.0", PORT), Handler) as httpd:
+        httpd.serve_forever()

--- a/start_all.py
+++ b/start_all.py
@@ -62,6 +62,11 @@ def main() -> int:
             raise SystemExit(f"UI gate failed: {msg}")
         log.info("UI healthy: %s", UI_HEALTH_URL)
 
+    # Allow CI to stop after gates so jobs don't hang:
+    if os.getenv("START_ALL_EXIT_AFTER_GATES", "0") == "1":
+        log.info("All gates green; exiting due to START_ALL_EXIT_AFTER_GATES=1")
+        return 0
+
     if os.getenv("CHECK_DEPTH_SERVICE", "0") == "1":
         ok, msg = wait_for(check_depth_service)
         if not ok:


### PR DESCRIPTION
## Summary
- add FastAPI-based mock RL daemon and simple HTTP mock UI
- allow `start_all.py` to exit after health gates via `START_ALL_EXIT_AFTER_GATES`
- wire up GitHub Actions workflow for paper-safe E2E run with Redis + mock services
- document the workflow in README

## Testing
- `pytest -q` *(fails: function() argument 'code' must be code, not str; ModuleNotFoundError: pytest_asyncio)*
- `pip install pytest-asyncio solana`
- `pytest tests/test_startup_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aec83798688331857a53e4214d127a